### PR TITLE
Adding support for joining on _id in a view

### DIFF
--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -571,9 +571,9 @@ class Views extends CompositeBase
                 {
                     // single value for join
                     $joinUris[] = array(_ID_RESOURCE=>$source[$predicate][VALUE_URI],_ID_CONTEXT=>$contextAlias);
-                }
-                else
-                {
+                } else if($predicate == '_id') {
+                    $joinUris[] = array(_ID_RESOURCE => $source[$predicate][_ID_RESOURCE], _ID_CONTEXT => $contextAlias);
+                } else {
                     // multiple values for join
                     $joinsPushed = 0;
                     foreach ($source[$predicate] as $v)

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -53,6 +53,24 @@ class MongoTripodViewsTest extends MongoTripodTestBase
 
         // load base data
         $this->loadResourceDataViaTripod();
+
+        $relatedContentTripod = $this->getMockBuilder(Tripod\Mongo\Driver::class)
+            ->onlyMethods([])
+            ->setConstructorArgs([
+                'CBD_test_related_content',
+                'tripod_php_testing',
+                [
+                    'defaultContext' => 'http://talisaspire.com/',
+                    'async' => [OP_VIEWS => true], // don't generate views syncronously when saving automatically - let unit tests deal with this)
+                ],
+            ])
+            ->getMock();
+        $docs = json_decode(file_get_contents(dirname(__FILE__) . '/data/relatedContent.json'), true);
+        foreach ($docs as $d) {
+            $g = new Tripod\Mongo\MongoGraph();
+            $g->add_tripod_array($d);
+            $relatedContentTripod->saveChanges(new Tripod\ExtendedGraph(), $g, $d['_id'][_ID_CONTEXT]);
+        }
     }
 
     /**
@@ -77,6 +95,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase
                             [VALUE_URI => 'bibo:Book'],
                             [VALUE_URI => 'acorn:Work'],
                         ],
+                    ],
+                    [
+                        '_id' => ['r' => 'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', 'c' => 'http://talisaspire.com/'],
+                        'dct:title' => ['l' => 'Title of the related resource content joined by id']
                     ],
                     [
                         '_id' => ['r' => 'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', 'c' => 'http://talisaspire.com/'],
@@ -105,6 +127,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase
         $this->assertEquals($expectedView['_id'], $actualView['_id']);
         $this->assertEquals($expectedView['value'], $actualView['value']);
         $this->assertInstanceOf(MongoDB\BSON\UTCDateTime::class, $actualView['_cts']);
+
     }
 
     /**

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -46,6 +46,11 @@
                         }
                     }
                 },
+                "CBD_test_related_content": {
+                    "cardinality": {
+                        "dct:created": 1
+                    }
+                },
                 "CBD_testing_2": {
                     "data_source" : "rs2",
                     "cardinality": {
@@ -75,6 +80,12 @@
                     "joins": {
                         "dct:isVersionOf": {
                             "include": ["dct:subject", "rdf:type"]
+                        },
+                        "_id": {
+                            "from": "CBD_test_related_content",
+                            "include": [
+                                "dct:title"
+                            ]
                         }
                     }
                 },

--- a/test/unit/mongo/data/relatedContent.json
+++ b/test/unit/mongo/data/relatedContent.json
@@ -1,0 +1,18 @@
+[
+  {
+    "_id": {
+      "r":"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA",
+      "c":"http://talisaspire.com/"
+    },
+    "_version": 0,
+    "rdf:type":[
+      {
+        "u":"http://talisaspire.com/schema#ResourceContent"
+      }
+    ],
+    "dct:title":
+    {
+      "l":"Title of the related resource content joined by id"
+    }
+  }
+]


### PR DESCRIPTION
**Background**

Tables allow you to join on an `_id` field, for example: https://github.com/techfromsage/rl-app/blob/ca940e8c1ce84a95079535106b2652fc4ea6b612/environmentconfig/tripod/tenant-tablespecs.json#L1571

But it's not supported in views, even though it would be quite useful.